### PR TITLE
Pass `truncate` through to `project_geom` as well

### DIFF
--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -359,3 +359,31 @@ def test_find_extrema():
 #         190.0099999999,
 #         85.0511287798066,
 #     )
+
+
+def test_truncate():
+    """Make sure the features are correctly truncated"""
+    features = [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        (-180.0, -50.00000149011612),
+                        (-180.0, 50.0),
+                        (180.00000536441803, 50.0),
+                        (180.00000536441803, -50.00000149011612),
+                        (-180.0, -50.00000149011612),
+                    ]
+                ],
+            },
+        }
+    ]
+    tms = morecantile.tms.get("WebMercatorQuad")
+
+    burntiles = burnTiles(tms=tms)
+    assert len(burntiles.burn(features, 1, truncate=True)) > 0
+
+    burntiles = burnTiles(tms=tms)
+    assert len(burntiles.burn(features, 1, truncate=False)) == 0


### PR DESCRIPTION
I found that the output of `burnTiles` was coming back empty on the following feature, even with `truncate=True`:

```
    features = [
        {
            "type": "Feature",
            "geometry": {
                "type": "Polygon",
                "coordinates": [
                    [
                        (-180.0, -50.00000149011612),
                        (-180.0, 50.0),
                        (180.00000536441803, 50.0),
                        (180.00000536441803, -50.00000149011612),
                        (-180.0, -50.00000149011612),
                    ]
                ],
            },
        }
    ]
```

However, if the `180.00000536441803` was replaced with `180.0`, then things were working as expected. I believe this was because the coordinates were not also being truncated, and indeed there were warnings coming from `xy`:

```
morecantile/models.py:810: PointOutsideTMSBounds: Point (180.00000536441803, 50.0) is outside TMS bounds [-180.0, -85.05112877980655, 179.99999999999955, 85.0511287798066].
```

Passing `truncate` through `project_geom` and into `xy` seemed like the correct fix, but I could be wrong, so please feel free to suggest another approach if I have misunderstood. The test I added does fail before this change.